### PR TITLE
fix deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         sudo tar -zxvf alphasql_linux_x86_64.tar.gz -C /usr/local/bin --strip=1
         rm alphasql_linux_x86_64.tar.gz
     - run: alphadag --output_path ./dag.dot .
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0
       with:
         version: '270.0.0'
         service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
## Summary
`google-github-actions/setup-gcloud@master`がサポートされなくなったことが原因と考えられるため、修正を行った。
[参考記事(stackoverflow)](https://stackoverflow.com/questions/71578595/github-actions-error-on-run-google-github-actions-setup-gcloudmaster-how-to)
<img width="1433" alt="スクリーンショット 2022-11-04 23 44 36" src="https://user-images.githubusercontent.com/57622015/200008404-0b968806-72a3-45a5-840a-0cf0dbfdf118.png">

## Related Issue
https://github.com/na0fu3y/bqfunc/issues/29

## Comment
挙動確認は行えてないですmm